### PR TITLE
Ignore assets.zip and assets folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ pixi.lock
 
 # OS
 .DS_Store
+
+# Downloaded assets
+assets/
+assets.zip
+__MACOSX/


### PR DESCRIPTION
to avoid accidentally checking in the asset files